### PR TITLE
Update mainEmotion

### DIFF
--- a/packages/backend/jest-testing/mainEmotion.test.js
+++ b/packages/backend/jest-testing/mainEmotion.test.js
@@ -11,6 +11,7 @@ test("Gets emotion with highest score", async () => {
     { name: "Joy", score: 0.3 },
     { name: "Romance", score: 0.1 },
     { name: "Excitement", score: 0.2 },
+    { name: "Surprise", score: 0.9 },
   ];
 
   expect(getMainEmotion(emotions)).toEqual("Boredom");

--- a/packages/backend/services/generateSeed.js
+++ b/packages/backend/services/generateSeed.js
@@ -19,7 +19,12 @@ function getMeasure(weights, userScores) {
     .map((emotion, i) => emotion * userScores[i])
     .sort()
     .slice(-3);
-  return weightedEmotions.reduce((a, v) => a + v, 0) / weightedEmotions.length;
+  const normWeighted = weightedEmotions.map(
+    (n) =>
+      (n - Math.min(...weightedEmotions)) /
+      (Math.max(...weightedEmotions) - Math.min(...weightedEmotions)),
+  );
+  return normWeighted.reduce((a, v) => a + v, 0) / 3;
 }
 
 /**

--- a/packages/backend/services/mainEmotion.js
+++ b/packages/backend/services/mainEmotion.js
@@ -4,8 +4,20 @@
  * @return {String}        Emotion with highest rating
  */
 function getMainEmotion(emotion) {
+  const emotions = [
+    "Anger",
+    "Anxiety",
+    "Boredom",
+    "Calmness",
+    "Concentration",
+    "Joy",
+    "Romance",
+    "Excitement",
+  ];
+
   return emotion.reduce(
-    (max, em) => (em.score > max.score ? em : max),
+    (max, em) =>
+      em.score > max.score && emotions.includes(em.name) ? em : max,
     emotion[0],
   ).name;
 }


### PR DESCRIPTION
Since Hume generates like 30-40 different emotion values and we are only analyzing 8 (Actually 3 per seed attribute on current deployment, might change later), I figure the "Emotion" column for recommendation should display the primary emotion of the 8 we analyze, not all of Hume's emotions. 

For example, one of my suggestions says the emotion is "Surprise (positive)" which is not something we generate recommendations based on. 

This choice only affects the UX, so if anyone disagrees with my opinion on this let me know and we can decide as a team what is best!
